### PR TITLE
Move from File::Slurp to Path::Tiny

### DIFF
--- a/Task/Read-entire-file/Perl/read-entire-file-3.pl
+++ b/Task/Read-entire-file/Perl/read-entire-file-3.pl
@@ -1,2 +1,2 @@
-use File::Slurp;
-my $text = read_file($filename);
+use Path::Tiny;
+my $text = path($filename)->slurp;


### PR DESCRIPTION
This change moves from File::Slurp to Path::Tiny.
File::Slurp is known to be buggy and vulnerable.
See also:

https://rt.cpan.org/Public/Bug/Display.html?id=95484
