### PR TITLE
Fixed Haversine formula in Kotlin

### DIFF
--- a/Task/Haversine-formula/Kotlin/haversine-formula.kotlin
+++ b/Task/Haversine-formula/Kotlin/haversine-formula.kotlin
@@ -7,7 +7,7 @@ const val R = 6372.8 // in kilometers
 fun haversine(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
     val λ1 = toRadians(lat1)
     val λ2 = toRadians(lat2)
-    val Δλ = toRadians(λ2 - λ1)
+    val Δλ = λ2 - λ1
     val Δφ = toRadians(lon2 - lon1)
     return 2 * R * asin(sqrt(pow(sin(Δλ / 2), 2.0) + pow(sin(Δφ / 2), 2.0) * cos(λ1) * cos(λ2)))
 }


### PR DESCRIPTION
Delta lambda must not be converted to radians, because it's already in radians