### PR TITLE
Fixed file extension for Arturo scripts

### DIFF
--- a/Conf/lang.yaml
+++ b/Conf/lang.yaml
@@ -60,7 +60,7 @@ Arendelle: .arendelle
 Argile: .argile
 ARM Assembly: .arm
 ArnoldC: .arnoldc
-Arturo: .arturo
+Arturo: .art
 AsciiDots: .asciidots
 ASIC: .asic
 ASP: .asp


### PR DESCRIPTION
I've noticed that Arturo scripts had an erroneous extension (`.arturo` vs `.art` which is the correct one), so... I've fixed it! 😉 

Please, let me know in case there is anything else I have to edit for the change to come into effect. 🚀 